### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/web_server.py
+++ b/web_server.py
@@ -120,4 +120,5 @@ def download_log():
     return "Log file not found."
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/Stalin-143/Keylogger/security/code-scanning/1](https://github.com/Stalin-143/Keylogger/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Modify the `app.run()` call to use an environment variable to determine whether to run in debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
